### PR TITLE
Glitch and test fixes

### DIFF
--- a/cachemachine_test.go
+++ b/cachemachine_test.go
@@ -657,7 +657,7 @@ func BenchmarkMergeAndReset(b *testing.B) {
 	var c2 = initializeFullCache(2, nil)
 
 	for n := 0; n < b.N; n++ {
-		MergeAndReset[int, int](c1, c2)
+		MergeAndReset[int, int](c1, &c2)
 	}
 
 }


### PR DESCRIPTION
Changed comment for cache method "Get"
Also, internally cache method "Get" now uses private method "getEntry"
Added brand-new cache method, "GetValue", this returns only value
Cache method "GetAllAndRemove" now has pointer receiver. This is done because it was failing its test